### PR TITLE
Fixed create deck

### DIFF
--- a/src/app/dashboard/create/createAction.ts
+++ b/src/app/dashboard/create/createAction.ts
@@ -24,10 +24,11 @@ export async function createDeckAction({ title, description, topics, flashcards,
   await createDeck({
     userId: data.user.id,
     deck: {
+      id: crypto.randomUUID(), // Temporary ID, will be ignored by the database
       title,
       description,
       topics,
-      flashcards: flashcards.map(({ term, definition }) => ({ term, definition })),
+      flashcards: flashcards.map(({ id, term, definition }) => ({ id, term, definition })),
       cardCount: flashcards.length,
       folderId: folderId || undefined,
     }

--- a/src/components/create-flashcards-dialog.tsx
+++ b/src/components/create-flashcards-dialog.tsx
@@ -1,3 +1,7 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -7,54 +11,62 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog"
 import { Plus } from "lucide-react"
-import Link from "next/link"
 
 export function CreateFlashcardsDialog() {
+  const [open, setOpen] = useState(false)
+  const router = useRouter()
+
+  const handleNavigateToUpload = () => {
+    setOpen(false)
+    router.push("/dashboard/upload")
+  }
+
+  const handleNavigateToCreate = () => {
+    setOpen(false)
+    router.push("/dashboard/create")
+  }
+
   return (
-    <Dialog>
-      <form>
-        <DialogTrigger asChild>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
         <Button
           size="lg"
           className="bg-gradient-to-r from-orange-500 to-purple-600 hover:from-orange-600 hover:to-purple-700 h-10 w-10 rounded-full"
         >
-            <Plus/>
-          </Button>
-        </DialogTrigger>
-        <DialogContent className="sm:max-w-4xl p-11">
-          <DialogHeader>
-            <DialogTitle className="text-center">How do you want to create your flashcard set</DialogTitle>
-          </DialogHeader>
-          <div className="grid gap-4">
-            <div className="flex flex-col sm:flex-row gap-5 w-full items-stretch">
-              {/* Card 1: Generate from an upload */}
-              <Link href="/dashboard/upload" className="flex-1">
-                <button
-                  type="button"
-                  className="w-full flex-1 min-h-40 rounded-lg border border-gray-200 bg-white shadow hover:shadow-md transition p-6 flex flex-col items-center justify-center gap-2"
-                >
-                  <span className="font-semibold text-lg">Generate from an upload</span>
-                  <span className="text-sm text-gray-500 text-center">
-                    Upload a PDF or document and we&apos;ll generate flashcards for you.
-                  </span>
-                </button>
-              </Link>
-              {/* Card 2: Create them yourself */}
-              <Link href="/dashboard/create" className="flex-1">
-                <button
-                  type="button"
-                  className="w-full flex-1 min-h-40 rounded-lg border border-gray-200 bg-white shadow hover:shadow-md transition p-6 flex flex-col items-center justify-center gap-2"
-                >
-                  <span className="font-semibold text-lg">Create them yourself</span>
-                  <span className="text-sm text-gray-500 text-center">
-                    Manually add your own questions and answers.
-                  </span>
-                </button>
-              </Link>
-            </div>
+          <Plus/>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-4xl p-11">
+        <DialogHeader>
+          <DialogTitle className="text-center">How do you want to create your flashcard set</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4">
+          <div className="flex flex-col sm:flex-row gap-5 w-full items-stretch">
+            {/* Card 1: Generate from an upload */}
+            <button
+              type="button"
+              onClick={handleNavigateToUpload}
+              className="w-full flex-1 min-h-40 rounded-lg border border-gray-200 bg-white shadow hover:shadow-md transition p-6 flex flex-col items-center justify-center gap-2"
+            >
+              <span className="font-semibold text-lg">Generate from an upload</span>
+              <span className="text-sm text-gray-500 text-center">
+                Upload a PDF or document and we&apos;ll generate flashcards for you.
+              </span>
+            </button>
+            {/* Card 2: Create them yourself */}
+            <button
+              type="button"
+              onClick={handleNavigateToCreate}
+              className="w-full flex-1 min-h-40 rounded-lg border border-gray-200 bg-white shadow hover:shadow-md transition p-6 flex flex-col items-center justify-center gap-2"
+            >
+              <span className="font-semibold text-lg">Create them yourself</span>
+              <span className="text-sm text-gray-500 text-center">
+                Manually add your own questions and answers.
+              </span>
+            </button>
           </div>
-        </DialogContent>
-      </form>
+        </div>
+      </DialogContent>
     </Dialog>
   )
 }


### PR DESCRIPTION
Fixed the Linter Error in createAction.ts
Added the missing id property in the flashcards mapping to satisfy the FlashcardEntry interface Added a temporary id to the deck object to satisfy the DeckEntry interface (this gets ignored by the database)

Converted the CreateFlashcardsDialog to a controlled component with state management Replaced the Link components with proper button click handlers Each option now:
Immediately closes the modal by setting setOpen(false) Navigates to the correct route using router.push()